### PR TITLE
Bump Java runtime version from 11 to 21

### DIFF
--- a/system.properties
+++ b/system.properties
@@ -1,1 +1,1 @@
-java.runtime.version=11
+java.runtime.version=21


### PR DESCRIPTION
With the latest Metabase release, they seem to bump minimally supported Java runtime.
From what I see, currently recommended version is 21:
https://www.metabase.com/docs/latest/installation-and-operation/running-the-metabase-jar-file

Since we are not pinning Metabase to a specific version by default, but using `latest`, it'd be good to bump the runtime version as well.


If anyone is looking for upgrade instructions:
https://www.metabase.com/docs/latest/installation-and-operation/upgrading-metabase
(with this buildpack, it is enough to back up the Metabase database, the rest is handled automatically)